### PR TITLE
update: update `reqwest` version to `^0.13`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ergoreq"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 description = "A human-centric web request client developed based on Reqwest, supporting automatic cookie management, automatic retries, and custom middleware."
@@ -12,9 +12,11 @@ repository = "https://github.com/RecordingTheSmile/ergoreq"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "^0", default-features = false, features = [
+reqwest = { version = "^0.13", default-features = false, features = [
     "json",
     "multipart",
+    "query",
+    "form",
 ] }
 paste = { version = "^1" }
 serde = "^1"
@@ -30,9 +32,7 @@ tracing = "^0"
 
 [dev-dependencies]
 tokio = { version = "^1", features = ["full"] }
-reqwest = { version = "^0", features = [
-    "rustls-tls",
-], default-features = false }
+reqwest = { version = "^0.13", features = ["rustls"], default-features = false }
 serde_json = "^1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ More examples can be found in [examples](examples) directory.
 
 # Requirement
 
-The tested `reqwest` version is 0.12. Using `reqwest` older than 0.12 may cause compile error.
+The current version supports `reqwest` version `^0.13`.
 
 # License
 

--- a/src/wrappers/request_builder_wrapper.rs
+++ b/src/wrappers/request_builder_wrapper.rs
@@ -258,12 +258,6 @@ impl ErgoRequestBuilder {
         self
     }
 
-    /// See [`RequestBuilder::fetch_mode_no_cors`]
-    pub fn fetch_mode_no_cors(mut self) -> Self {
-        self.inner = self.inner.fetch_mode_no_cors();
-        self
-    }
-
     /// See [`RequestBuilder::multipart`]
     ///
     /// ## Notice


### PR DESCRIPTION
This pull request updates the project to support newer versions of `reqwest` and removes an obsolete method from the request builder wrapper. The main focus is on dependency upgrades and code cleanup for better compatibility and maintainability.

**Dependency upgrades:**

* Updated the main `reqwest` dependency to version `^0.13` and added the `"query"` and `"form"` features for enhanced request capabilities.
* Updated the dev-dependency `reqwest` to version `^0.13` and changed the TLS feature from `"rustls-tls"` to `"rustls"` for improved compatibility.
* Updated the project version in `Cargo.toml` from `0.2.1` to `0.3.0` to reflect these significant changes.

**Documentation update:**

* Updated the `README.md` to clarify that the supported `reqwest` version is now `^0.13`.

**Code cleanup:**

* Removed the `fetch_mode_no_cors` method from `ErgoRequestBuilder`, as it is no longer relevant or supported.